### PR TITLE
Move .INI settings to Project Settings and replace autoloads with dependency injection

### DIFF
--- a/Accessible.gd
+++ b/Accessible.gd
@@ -1,6 +1,12 @@
 extends Node
 
+var TTS
+
 var node
+
+var should_stop_on_focus = true
+
+var logging
 
 var position_in_children = 0
 
@@ -15,7 +21,8 @@ func get_siblings():
 
 
 func click(item := node, button_index = BUTTON_LEFT):
-	print_debug("Click")
+	if logging:
+		print_debug("Click")
 	var click = InputEventMouseButton.new()
 	click.button_index = button_index
 	click.pressed = true
@@ -77,7 +84,7 @@ func _accept_dialog_focused():
 
 func _accept_dialog_about_to_show():
 	_accept_dialog_speak()
-	ScreenReader.should_stop_on_focus = false
+	should_stop_on_focus = false
 
 
 func _basebutton_button_down():
@@ -181,7 +188,8 @@ func item_list_item_focused(idx):
 func item_list_focused():
 	var count = node.get_item_count()
 	var selected = node.get_selected_items()
-	print_debug(selected)
+	if logging:
+		print_debug(selected)
 	if len(selected) == 0:
 		if node.get_item_count() == 0:
 			return TTS.speak("list, 0 items", false)
@@ -312,7 +320,8 @@ func popup_menu_focused():
 
 
 func popup_menu_item_id_focused(index):
-	print_debug("item id focus %s" % index)
+	if logging:
+		print_debug("item id focus %s" % index)
 	var tokens = PoolStringArray([])
 	var shortcut = node.get_item_shortcut(index)
 	var name
@@ -586,10 +595,11 @@ func tab_container_input(event):
 
 
 func focused():
-	print_debug("Focus: %s" % node)
-	if ScreenReader.should_stop_on_focus:
+	if logging:
+		print_debug("Focus: %s" % node)
+	if should_stop_on_focus:
 		TTS.stop()
-	ScreenReader.should_stop_on_focus = true
+	should_stop_on_focus = true
 	if not node is Label:
 		var label = _guess_label()
 		if label:
@@ -633,7 +643,8 @@ func focused():
 		tree_focused()
 	else:
 		TTS.speak(node.get_class(), true)
-		print_debug("No handler")
+		if logging:
+			print_debug("No handler")
 	if node.hint_tooltip and not spoke_hint_tooltip:
 		TTS.speak(node.hint_tooltip, false)
 	spoke_hint_tooltip = false
@@ -733,7 +744,9 @@ func editor_inspector_section_input(event):
 			TTS.speak("collapsed", true)
 
 
-func _init(node):
+func _init(node, tts, console_logging: bool):
+	TTS = tts
+	logging = console_logging
 	name = "Accessible for " + node.name
 	if node.is_in_group("accessible"):
 		return

--- a/Accessible.gd
+++ b/Accessible.gd
@@ -1,16 +1,14 @@
 extends Node
 
-var TTS
-
 var node
-
-var should_stop_on_focus = true
-
-var logging
 
 var position_in_children = 0
 
 var column_in_row = 0
+
+var screen_reader
+
+var TTS
 
 
 func get_siblings():
@@ -21,7 +19,7 @@ func get_siblings():
 
 
 func click(item := node, button_index = BUTTON_LEFT):
-	if logging:
+	if screen_reader.logging:
 		print_debug("Click")
 	var click = InputEventMouseButton.new()
 	click.button_index = button_index
@@ -84,7 +82,7 @@ func _accept_dialog_focused():
 
 func _accept_dialog_about_to_show():
 	_accept_dialog_speak()
-	should_stop_on_focus = false
+	screen_reader.should_stop_on_focus = false
 
 
 func _basebutton_button_down():
@@ -188,7 +186,7 @@ func item_list_item_focused(idx):
 func item_list_focused():
 	var count = node.get_item_count()
 	var selected = node.get_selected_items()
-	if logging:
+	if screen_reader.logging:
 		print_debug(selected)
 	if len(selected) == 0:
 		if node.get_item_count() == 0:
@@ -320,7 +318,7 @@ func popup_menu_focused():
 
 
 func popup_menu_item_id_focused(index):
-	if logging:
+	if screen_reader.logging:
 		print_debug("item id focus %s" % index)
 	var tokens = PoolStringArray([])
 	var shortcut = node.get_item_shortcut(index)
@@ -595,11 +593,11 @@ func tab_container_input(event):
 
 
 func focused():
-	if logging:
+	if screen_reader.logging:
 		print_debug("Focus: %s" % node)
-	if should_stop_on_focus:
+	if screen_reader.should_stop_on_focus:
 		TTS.stop()
-	should_stop_on_focus = true
+	screen_reader.should_stop_on_focus = true
 	if not node is Label:
 		var label = _guess_label()
 		if label:
@@ -643,7 +641,7 @@ func focused():
 		tree_focused()
 	else:
 		TTS.speak(node.get_class(), true)
-		if logging:
+		if screen_reader.logging:
 			print_debug("No handler")
 	if node.hint_tooltip and not spoke_hint_tooltip:
 		TTS.speak(node.hint_tooltip, false)
@@ -744,9 +742,9 @@ func editor_inspector_section_input(event):
 			TTS.speak("collapsed", true)
 
 
-func _init(node, tts, console_logging: bool):
+func _init(node, reader, tts):
+	screen_reader = reader
 	TTS = tts
-	logging = console_logging
 	name = "Accessible for " + node.name
 	if node.is_in_group("accessible"):
 		return

--- a/Plugin.gd
+++ b/Plugin.gd
@@ -1,9 +1,34 @@
 tool
 extends EditorPlugin
 
+var TTS
+
+var TtsClass = preload("../godot-tts/TTS.gd")
+
 var ScreenReader = preload("ScreenReader.gd")
 
 var screen_reader
+
+
+func _initialise_settings() -> void:
+	_add_setting("In_Editor", TYPE_BOOL, true)
+	_add_setting("Logging", TYPE_BOOL, true)
+	_add_setting("Speech_Rate", TYPE_INT, 50)
+	ProjectSettings.save()
+	
+	
+func _add_setting(title: String, type: int, value, hint_type: int = -1, hint_string = "") -> void:
+	title = title.insert(0, "Accessibility/")
+	if ProjectSettings.has_setting(title):
+		return
+	ProjectSettings.set(title, value)
+	var prop: Dictionary = {}
+	prop["name"] = title
+	prop["type"] = type
+	if hint_type > -1:
+		prop["hint"] = hint_type
+		prop["hint_string"] = hint_string
+	ProjectSettings.add_property_info(prop)
 
 
 func set_initial_screen_focus(screen):
@@ -22,19 +47,13 @@ func set_initial_screen_focus(screen):
 
 
 func _enter_tree():
-	var editor_accessibility_enabled = true
-	add_autoload_singleton("TTS", "res://addons/godot-tts/TTS.gd")
-	var rate = TTS.normal_rate
-	var config = ConfigFile.new()
-	var err = config.load("res://.godot-accessibility-editor-settings.ini")
-	if not err:
-		editor_accessibility_enabled = config.get_value(
-			"global", "editor_accessibility_enabled", true
-		)
-		rate = config.get_value("speech", "rate", 50)
-	if editor_accessibility_enabled:
-		TTS.call_deferred("_set_rate", rate)
-		screen_reader = ScreenReader.new()
+	_initialise_settings()
+	TTS = TtsClass.new()
+	var rate = ProjectSettings.get_setting("Accessibility/Speech_Rate")
+	TTS.call_deferred("_set_rate", rate)
+	var logging = ProjectSettings.get_setting("Accessibility/Logging")
+	if ProjectSettings.get_setting("Accessibility/In_Editor"):
+		screen_reader = ScreenReader.new(TTS, logging)
 		screen_reader.enable_focus_mode = true
 		get_tree().root.call_deferred("add_child", screen_reader)
 	add_custom_type("ScreenReader", "Node", preload("ScreenReader.gd"), null)
@@ -48,7 +67,7 @@ var _focus_loss_interval = 0
 
 
 func _process(delta):
-	if not screen_reader.enabled:
+	if not screen_reader or not screen_reader.enabled:
 		return
 	var focus = screen_reader.find_focusable_control(get_tree().root)
 	focus = focus.get_focus_owner()

--- a/Plugin.gd
+++ b/Plugin.gd
@@ -1,38 +1,40 @@
 tool
 extends EditorPlugin
 
-var TTS
-
-var TtsClass = preload("../godot-tts/TTS.gd")
-
 var ScreenReader = preload("ScreenReader.gd")
 
 var screen_reader
 
+var TTS
+
+var editor_settings
+
+const settings_path = "interface/accessibility/"
+
 
 func _initialise_settings() -> void:
-	_add_setting("In_Editor", TYPE_BOOL, true)
-	_add_setting("Logging", TYPE_BOOL, true)
+	editor_settings = get_editor_interface().get_editor_settings()
+	_add_setting("In_Editor", TYPE_BOOL, false)
+	_add_setting("Logging", TYPE_BOOL, false)
 	_add_setting("Speech_Rate", TYPE_INT, 50)
-	ProjectSettings.save()
 	
 	
 func _add_setting(title: String, type: int, value, hint_type: int = -1, hint_string = "") -> void:
-	title = title.insert(0, "Accessibility/")
-	if ProjectSettings.has_setting(title):
+	title = title.insert(0, settings_path)
+	if editor_settings.has_setting(title):
 		return
-	ProjectSettings.set(title, value)
+	editor_settings.set(title, value)
 	var prop: Dictionary = {}
 	prop["name"] = title
 	prop["type"] = type
 	if hint_type > -1:
 		prop["hint"] = hint_type
 		prop["hint_string"] = hint_string
-	ProjectSettings.add_property_info(prop)
+	editor_settings.add_property_info(prop)
 
 
 func set_initial_screen_focus(screen):
-	if not screen_reader.enabled:
+	if not screen_reader or not screen_reader.enabled:
 		return
 	TTS.speak("%s: screen" % screen, false)
 	var control = screen_reader.find_focusable_control(get_tree().root)
@@ -48,13 +50,14 @@ func set_initial_screen_focus(screen):
 
 func _enter_tree():
 	_initialise_settings()
-	TTS = TtsClass.new()
-	var rate = ProjectSettings.get_setting("Accessibility/Speech_Rate")
-	TTS.call_deferred("_set_rate", rate)
-	var logging = ProjectSettings.get_setting("Accessibility/Logging")
-	if ProjectSettings.get_setting("Accessibility/In_Editor"):
-		screen_reader = ScreenReader.new(TTS, logging)
+	var rate = editor_settings.get_setting(settings_path + "Speech_Rate")
+	var logging = editor_settings.get_setting(settings_path + "Logging")
+	if editor_settings.get_setting(settings_path + "In_Editor"):
+		screen_reader = ScreenReader.new()
 		screen_reader.enable_focus_mode = true
+		screen_reader.logging = logging
+		TTS = screen_reader.TTS
+		TTS.call_deferred("_set_rate", rate)
 		get_tree().root.call_deferred("add_child", screen_reader)
 	add_custom_type("ScreenReader", "Node", preload("ScreenReader.gd"), null)
 

--- a/ScreenReader.gd
+++ b/ScreenReader.gd
@@ -11,6 +11,10 @@ signal swipe_down
 
 var Accessible = preload("Accessible.gd")
 
+var TTS
+
+var logging
+
 export var enabled = true setget _set_enabled, _get_enabled
 
 export var min_swipe_distance = 5
@@ -20,8 +24,6 @@ export var tap_execute_interval = 125
 export var explore_by_touch_interval = 200
 
 export var enable_focus_mode = false
-
-var should_stop_on_focus = true
 
 func _set_enabled(v):
 	if enabled:
@@ -40,7 +42,7 @@ func augment_node(node):
 	if not enabled:
 		return
 	if node is Control:
-		Accessible.new(node)
+		Accessible.new(node, TTS, logging)
 
 
 func augment_tree(node):
@@ -65,6 +67,11 @@ func find_focusable_control(node):
 		if result:
 			return result
 	return null
+
+
+func _init(tts, console_logging: bool):
+	TTS = tts
+	logging = console_logging
 
 
 func _enter_tree():


### PR DESCRIPTION
This merge request:
- Moves settings from the .INI file to project settings. This makes it more convenient for sighted people, and I hope it is at least just as accessible. The settings are put in project.godot under "[Accessibility]".
- Replaces autoloaded TTS instance with a single instance trough dependency injection, to keep the autoloads strictly for the game itself.
- Make loggin configurable, so it can be disabled to keep the console output for other things.

The settings are:
```
[Accessibility]

In_Editor=true
Logging=true
Speech_Rate=50
```

I got the inspiration for how to make the settings available in project settings from WAT-Sharp.

These were just changes which were convenient for me personally, so let me know if I should change anything :)